### PR TITLE
New strict/nullable split for TimeSeries and TimeSeries' 

### DIFF
--- a/src/Sibyl/TimeSeries.hs
+++ b/src/Sibyl/TimeSeries.hs
@@ -1,13 +1,13 @@
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FlexibleInstances #-}
 module Sibyl.TimeSeries where
 
 import qualified Data.Vector.Unboxed as U
 import qualified DataFrame as D
 import DataFrame (DataFrame, DataFrameException)
 import DataFrame.Internal.Column (Columnable)
-import qualified DataFrame.Functions as F
 import Data.Bifunctor (first)
 import Prelude hiding (drop)
 import Sibyl.Internal.Util
@@ -15,12 +15,13 @@ import qualified Data.Text as T
 
 -- * Error Types
 
--- | Error type for TimeSeries invariants and TimeSeries transformations (i.e. lag, diff, etc...)
+-- | Error type for TimeSeries invariants and transformations (i.e. lag, diff, etc.)
 data TimeSeriesError
   = LengthMismatch
   | NonMonotonicIndex
   | EmptySeries
   | IndexMismatch
+  | NullIndex                -- ^ One or more index values are missing
   -- Transformation errors
   | InvalidLag
   | InvalidLead
@@ -29,244 +30,343 @@ data TimeSeriesError
   | InsufficientObservations
   deriving (Show, Eq)
 
+-- | Error type for densification failures.
+data DensifyError
+  = EmptyAfterDrop           -- ^ 'DropMissing' would produce an empty series
+  deriving (Show, Eq)
+
 data ConversionError
   = ColumnNotFound T.Text
   | ColumnTypeMismatch T.Text
   | InvalidSeries TimeSeriesError
   | DataFrameError DataFrameException
 
--- * Unboxed Time Series
+-- * Fill Strategy
 
--- | Core univariate time series type internally represented by unboxed vectors.
+-- | Strategy for filling missing observations when converting 'TimeSeries' to 'TimeSeries''.
+data FillStrategy
+  = ForwardFill           -- ^ Propagate last valid observation forward
+  | BackwardFill          -- ^ Propagate next valid observation backward
+  | LinearInterpolation   -- ^ Linearly interpolate between adjacent valid observations
+  | DropMissing           -- ^ Drop all missing observations (shrinks the series)
+  deriving (Show, Eq)
+
+-- * Nullable Time Series
+
+-- | Univariate time series with a per-observation validity mask.
 --
 -- Invariants (enforced by 'mkTimeSeries'):
 --
--- * 'index' and 'observations' have equal length
--- * index must be strictly increasing (i.e. 1, 2, 3 and not 1, 1, 3)
--- * series is non-empty
+-- * 'index', 'observations', and 'validityMask' have equal length
+-- * 'index' is non-empty
+-- * 'index' is strictly increasing
 --
--- Prefer using 'mkTimeSeries' instead of record literals... you'll thank yourself later!
---
--- 'index' is the time axis and may be any ordered type (e.g. Int, Day, POSIX-like values),
--- not only consecutive integers.
---
--- This type does not have a 'Functor' instance because mapping over unboxed vectors
--- requires additional 'U.Unbox' constraints on output types.
+-- 'validityMask': @True@ = observation is present; @False@ = observation was never recorded.
+-- NaN in 'observations' is semantically distinct from @False@ in 'validityMask':
+-- NaN means a computation was undefined (e.g. 0\/0); @False@ means the datum was never collected.
 data TimeSeries t y = TimeSeries
-  { index        :: !(U.Vector t)   -- ^ Strictly increasing index of any ordered type.
-  , observations :: !(U.Vector y)   -- ^ Values (observations) aligned 1:1 with 'index'
+  { index        :: !(U.Vector t)      -- ^ Strictly increasing index of any ordered type
+  , observations :: !(U.Vector y)      -- ^ Values aligned 1:1 with 'index'
+  , validityMask :: !(U.Vector Bool)   -- ^ True = present, False = missing
   } deriving (Eq, Show)
+
+-- * Strict (Dense) Time Series
+
+-- | Dense time series: a 'TimeSeries' with the invariant that every entry in
+-- 'validityMask' is @True@.
+--
+-- Construct via 'mkTimeSeries'' or 'densify'. 
+newtype TimeSeries' t y = TimeSeries' { unTimeSeries' :: TimeSeries t y }
+  deriving (Eq, Show)
 
 type Period = Int
 
--- ** Construction
+-- * Series Typeclass
 
--- | Produces a `TimeSeries` from its inputs and enforces invariants.
+-- | Operations common to both 'TimeSeries' and 'TimeSeries''.
 --
--- * 'index' and 'observations' have equal length
--- * index must be strictly increasing (i.e. 1, 2, 3 and not 1, 1, 3)
--- * series is non-empty
+-- 'TimeSeries'' instances unwrap, apply the 'TimeSeries' logic, and rewrap.
+-- None of these operations introduce new gaps, so 'TimeSeries'' is closed under them.
+class Series s where
+  diff
+    :: (Num y, U.Unbox t, U.Unbox y)
+    => s t y -> Either TimeSeriesError (s t y)
+  lag
+    :: (U.Unbox t, U.Unbox y)
+    => Int -> s t y -> Either TimeSeriesError (s t y)
+  lead
+    :: (U.Unbox t, U.Unbox y)
+    => Int -> s t y -> Either TimeSeriesError (s t y)
+  slice
+    :: (Ord t, U.Unbox t, U.Unbox y)
+    => t -> t -> s t y -> Either TimeSeriesError (s t y)
+  takeFirst
+    :: (U.Unbox t, U.Unbox y)
+    => Int -> s t y -> Either TimeSeriesError (s t y)
+  takeLast
+    :: (U.Unbox t, U.Unbox y)
+    => Int -> s t y -> Either TimeSeriesError (s t y)
+  drop
+    :: (U.Unbox t, U.Unbox y)
+    => Int -> s t y -> Either TimeSeriesError (s t y)
+  zipWithSeries
+    :: (Eq t, U.Unbox t, U.Unbox a, U.Unbox b, U.Unbox c)
+    => (a -> b -> c) -> s t a -> s t b -> Either TimeSeriesError (s t c)
+  -- | Maps a function over the observation vector.
+  mapObservations
+    :: (U.Vector y -> b)
+    -> s t y -> b
+  -- | Maps observations with access to the aligned time index.
+  -- Validity is preserved: mapping does not change whether an observation was recorded.
+  mapWithIndex
+    :: (U.Unbox t, U.Unbox y, U.Unbox b)
+    => (t -> y -> b) -> s t y -> s t b
+
+-- ** TimeSeries instance
+
+instance Series TimeSeries where
+
+  -- | Differences consecutive observations. Drops the first index entry.
+  diff ts
+    | U.null timeIndex = Left EmptySeries
+    | n == 1           = Left InsufficientObservations
+    | otherwise        = Right ts
+        { index        = U.drop 1 timeIndex
+        , observations = U.zipWith (-) (U.drop 1 (observations ts)) (observations ts)
+        , validityMask  = U.drop 1 (validityMask ts)
+        }
+    where
+      timeIndex = index ts
+      n         = U.length timeIndex
+
+  -- | Shifts observations back by @k@. Output length is @n-k@.
+  lag k ts
+    | U.null timeIndex = Left EmptySeries
+    | k < 0            = Left InvalidLag
+    | k >= n           = Left InvalidLag
+    | otherwise        = Right ts
+        { index        = U.drop k timeIndex
+        , observations = U.take (n - k) (observations ts)
+        , validityMask  = U.take (n - k) (validityMask ts)
+        }
+    where
+      timeIndex = index ts
+      n         = U.length timeIndex
+
+  -- | Shifts observations forward by @k@. Output length is @n-k@.
+  lead k ts
+    | U.null timeIndex = Left EmptySeries
+    | k < 0            = Left InvalidLead
+    | k >= n           = Left InvalidLead
+    | otherwise        = Right ts
+        { index        = U.take (n - k) timeIndex
+        , observations = U.drop k (observations ts)
+        , validityMask  = U.drop k (validityMask ts)
+        }
+    where
+      timeIndex = index ts
+      n         = U.length timeIndex
+
+  -- | Returns a subseries bounded by start and end index values (inclusive).
+  slice start end ts
+    | start > end     = Left InvalidSlice
+    | U.null newIndex = Left EmptySeries
+    | otherwise       = Right ts
+        { index        = newIndex
+        , observations = U.slice drops remaining (observations ts)
+        , validityMask  = U.slice drops remaining (validityMask ts)
+        }
+    where
+      timeIndex = index ts
+      drops     = U.length (U.takeWhile (< start) timeIndex)
+      remaining = U.length (U.takeWhile (<= end) (U.drop drops timeIndex))
+      newIndex  = U.slice drops remaining timeIndex
+
+  -- | Keeps the first @k@ observations.
+  takeFirst k ts
+    | k < 0           = Left InvalidQuantity
+    | k > n           = Left InvalidQuantity
+    | U.null newIndex = Left EmptySeries
+    | otherwise       = Right ts
+        { index        = newIndex
+        , observations = U.take k (observations ts)
+        , validityMask  = U.take k (validityMask ts)
+        }
+    where
+      timeIndex = index ts
+      n         = tsLength ts
+      newIndex  = U.take k timeIndex
+
+  -- | Keeps the last @k@ observations.
+  takeLast k ts
+    | k < 0           = Left InvalidQuantity
+    | k > n           = Left InvalidQuantity
+    | U.null newIndex = Left EmptySeries
+    | otherwise       = Right ts
+        { index        = newIndex
+        , observations = U.drop (n - k) (observations ts)
+        , validityMask  = U.drop (n - k) (validityMask ts)
+        }
+    where
+      timeIndex = index ts
+      n         = tsLength ts
+      newIndex  = U.drop (n - k) timeIndex
+
+  -- | Drops the first @k@ observations.
+  drop k ts
+    | k < 0           = Left InvalidQuantity
+    | k > n           = Left InvalidQuantity
+    | U.null newIndex = Left EmptySeries
+    | otherwise       = Right ts
+        { index        = newIndex
+        , observations = U.drop k (observations ts)
+        , validityMask  = U.drop k (validityMask ts)
+        }
+    where
+      timeIndex = index ts
+      n         = tsLength ts
+      newIndex  = U.drop k timeIndex
+
+  -- | Combines two series point-wise. Indices must match exactly.
+  zipWithSeries f tsA tsB
+    | lenA /= lenB     = Left LengthMismatch
+    | indexA /= indexB = Left IndexMismatch
+    | otherwise        = Right TimeSeries
+        { index        = indexA
+        , observations = U.zipWith f (observations tsA) (observations tsB)
+        , validityMask  = undefined -- combine validity masks
+        }
+    where
+      lenA   = tsLength tsA
+      lenB   = tsLength tsB
+      indexA = index tsA
+      indexB = index tsB
+
+  mapObservations f ts = f (observations ts)
+
+  mapWithIndex f ts =
+    ts { observations = U.zipWith f (index ts) (observations ts) }
+
+-- ** TimeSeries' instance
+
+instance Series TimeSeries' where
+  diff (TimeSeries' ts)             = fmap TimeSeries' (diff ts)
+  lag k (TimeSeries' ts)            = fmap TimeSeries' (lag k ts)
+  lead k (TimeSeries' ts)           = fmap TimeSeries' (lead k ts)
+  slice s e (TimeSeries' ts)        = fmap TimeSeries' (slice s e ts)
+  takeFirst k (TimeSeries' ts)      = fmap TimeSeries' (takeFirst k ts)
+  takeLast k (TimeSeries' ts)       = fmap TimeSeries' (takeLast k ts)
+  drop k (TimeSeries' ts)           = fmap TimeSeries' (drop k ts)
+  zipWithSeries f (TimeSeries' a) (TimeSeries' b) = fmap TimeSeries' (zipWithSeries f a b)
+  mapObservations f (TimeSeries' ts) = f (observations ts)
+  mapWithIndex f (TimeSeries' ts)    = TimeSeries' (ts { observations = U.zipWith f (index ts) (observations ts) })
+
+-- * Construction
+
+-- | Constructs a 'TimeSeries', enforcing all invariants.
 --
--- Requires `U.Unbox` constraints on index and observation element types.
-mkTimeSeries :: (Ord t, U.Unbox t, U.Unbox y) => U.Vector t -> U.Vector y -> Either TimeSeriesError (TimeSeries t y)
-mkTimeSeries idx values
-  | ilen /= vlen                    = Left LengthMismatch
-  | U.null idx                      = Left EmptySeries
-  | not (strictlyIncreasing idx)    = Left NonMonotonicIndex
-  | otherwise                       = Right (TimeSeries idx values)
+-- The validity mask is optional: 'Nothing' defaults to all @True@ (fully present).
+-- The mask is derived automatically when constructing from a 'DataFrame' via 'fromDataFrame';
+-- users should not need to construct 'U.Vector Bool' directly.
+--
+-- Rejects if: lengths differ, index is empty, index is not strictly increasing,
+-- or any index value is null ('NullIndex').
+mkTimeSeries
+  :: (Ord t, U.Unbox t, U.Unbox y)
+  => U.Vector t
+  -> U.Vector y
+  -> Maybe (U.Vector Bool)
+  -> Either TimeSeriesError (TimeSeries t y)
+mkTimeSeries idx values mValidity
+  | ilen /= vlen                 = Left LengthMismatch
+  | U.null idx                   = Left EmptySeries
+  | not (strictlyIncreasing idx) = Left NonMonotonicIndex
+  | otherwise                    = Right (TimeSeries idx values validity)
   where
-    ilen = U.length idx
-    vlen = U.length values
+    ilen     = U.length idx
+    vlen     = U.length values
+    validity = maybe (U.replicate ilen True) id mValidity
 
--- | Splits a 'SeasonalSeries' into full-season chunks. Trailing incomplete season is dropped.
+-- | Constructs a dense 'TimeSeries'', additionally rejecting if any validity entry is @False@.
+mkTimeSeries'
+  :: (Ord t, U.Unbox t, U.Unbox y)
+  => U.Vector t
+  -> U.Vector y
+  -> Maybe (U.Vector Bool)
+  -> Either TimeSeriesError (TimeSeries' t y)
+mkTimeSeries' = undefined
+
+-- * Densification
+
+-- | Explicitly converts a nullable 'TimeSeries' to a dense 'TimeSeries'' using a FillStrategy.
+densify
+  :: (U.Unbox t, Fractional y, U.Unbox y)
+  => FillStrategy
+  -> TimeSeries t y
+  -> Either DensifyError (TimeSeries' t y)
+densify = undefined
+
+-- * Season Slices
+
+-- | Splits a series into full-season chunks. Trailing incomplete season is dropped.
 seasonSlices :: (U.Unbox t, U.Unbox y) => Int -> TimeSeries t y -> [TimeSeries t y]
 seasonSlices m ss =
-  [ TimeSeries (U.slice (i * m) m idx) (U.slice (i * m) m obs)
+  [ TimeSeries
+      (U.slice (i * m) m idx)
+      (U.slice (i * m) m obs)
+      (U.slice (i * m) m val)
   | i <- [0 .. fullSeasons - 1] ]
   where
     idx         = index ss
     obs         = observations ss
+    val         = validityMask ss
     fullSeasons = U.length obs `div` m
 
--- ** Sample Data
+-- * Sample Data
 
--- | Provides a sample `TimeSeries` for testing purposes.
+-- | Provides a sample 'TimeSeries' for testing purposes.
 sampleTimeSeries :: TimeSeries Int Double
-sampleTimeSeries =
-  TimeSeries
-    { index = U.fromList [1 .. 8]
-    , observations = U.fromList [101.0, 103.0, 102.5, 104.0, 106.0, 105.5, 107.0, 108.0]
-    }
+sampleTimeSeries = TimeSeries
+  { index        = U.fromList [1 .. 8]
+  , observations = U.fromList [101.0, 103.0, 102.5, 104.0, 106.0, 105.5, 107.0, 108.0]
+  , validityMask  = U.replicate 8 True
+  }
 
--- | Synonym for `sampleTimeSeries`
+-- | Synonym for 'sampleTimeSeries'.
 defaultTimeSeries :: TimeSeries Int Double
 defaultTimeSeries = sampleTimeSeries
 
--- ** Summary
+-- * Summary
 
--- | Returns integer length of a `TimeSeries`
+-- | Returns the integer length of a 'TimeSeries'.
 tsLength :: (U.Unbox t) => TimeSeries t y -> Int
 tsLength = U.length . index
 
--- | Returns the start time of a `TimeSeries`
+-- | Returns the start time of a 'TimeSeries'.
 tsStart :: (U.Unbox t) => TimeSeries t y -> t
 tsStart = U.head . index
 
--- | Returns the end time of a `TimeSeries`
+-- | Returns the end time of a 'TimeSeries'.
 tsEnd :: (U.Unbox t) => TimeSeries t y -> t
 tsEnd = U.last . index
 
--- ** Transformations
-
--- | Maps a function @f :: U.Vector y -> b@ over a `TimeSeries`.
---
--- __Example:__ using `Statistics.Sample` functions on a `TimeSeries`:
---
--- >>> mapObservations (Statistics.Sample.mean) (defaultTimeSeries)
--- 104.625
---
-mapObservations :: (U.Vector y -> b) -> TimeSeries t y -> b
-mapObservations f = f . observations
-
--- | Maps observations with access to the aligned time index.
-mapWithIndex :: (U.Unbox t, U.Unbox y, U.Unbox b) => (t -> y -> b) -> TimeSeries t y -> TimeSeries t b
-mapWithIndex f ts =
-  ts { observations = U.zipWith f (index ts) (observations ts) }
-
--- ** Combination And Slicing
-
--- | Combines two time series point-wise with a binary function.
-zipWithSeries :: (Eq t, U.Unbox a, U.Unbox b, U.Unbox c, U.Unbox t) => (a -> b -> c) -> TimeSeries t a -> TimeSeries t b -> Either TimeSeriesError (TimeSeries t c)
-zipWithSeries f tsA tsB
-  | lenA /= lenB     = Left LengthMismatch
-  | indexA /= indexB = Left IndexMismatch
-  | otherwise        = Right TimeSeries { index = indexA, observations = zipped }
-  where
-    lenA = tsLength tsA
-    lenB = tsLength tsB
-    indexA = index tsA
-    indexB = index tsB
-    obsA = observations tsA
-    obsB = observations tsB
-    zipped = U.zipWith f obsA obsB
-
--- | Returns a subseries bounded by start and end index values.
-slice :: (Ord t, U.Unbox t, U.Unbox y) => t -> t -> TimeSeries t y -> Either TimeSeriesError (TimeSeries t y)
-slice start end ts
-  | start > end      = Left InvalidSlice
-  | U.null newIndex  = Left EmptySeries
-  | otherwise        = Right ts { index = newIndex, observations = newObs }
-  where
-    timeIndex = index ts
-    obs = observations ts
-    drops = U.length (U.takeWhile (< start) timeIndex)
-    remaining = U.length (U.takeWhile (<= end) (U.drop drops timeIndex))
-    newIndex = U.slice drops remaining timeIndex
-    newObs = U.slice drops remaining obs
-
--- | Keeps the last @k@ observations.
-takeLast :: (U.Unbox t, U.Unbox y) => Int -> TimeSeries t y -> Either TimeSeriesError (TimeSeries t y)
-takeLast k ts
-  | k < 0            = Left InvalidQuantity
-  | k > n            = Left InvalidQuantity
-  | U.null newIndex  = Left EmptySeries
-  | otherwise        = Right ts { index = newIndex, observations = newObs }
-  where
-    timeIndex = index ts
-    obs = observations ts
-    n = tsLength ts
-    newIndex = U.drop (n - k) timeIndex
-    newObs = U.drop (n - k) obs
-
--- | Keeps the first @k@ observations.
-takeFirst :: (U.Unbox t, U.Unbox y) => Int -> TimeSeries t y -> Either TimeSeriesError (TimeSeries t y)
-takeFirst k ts
-  | k < 0            = Left InvalidQuantity
-  | k > n            = Left InvalidQuantity
-  | U.null newIndex  = Left EmptySeries
-  | otherwise        = Right ts { index = newIndex, observations = newObs }
-  where
-    timeIndex = index ts
-    obs = observations ts
-    n = tsLength ts
-    newIndex = U.take k timeIndex
-    newObs = U.take k obs
-
--- | Drops first @k@ observations.
-drop :: (U.Unbox t, U.Unbox y) => Int -> TimeSeries t y -> Either TimeSeriesError (TimeSeries t y)
-drop k ts
-  | k < 0            = Left InvalidQuantity
-  | k > n            = Left InvalidQuantity
-  | U.null newIndex  = Left EmptySeries
-  | otherwise        = Right ts { index = newIndex, observations = newObs }
-  where
-    timeIndex = index ts
-    obs = observations ts
-    n = tsLength ts
-    newIndex = U.drop k timeIndex
-    newObs = U.drop k obs
-
--- ** Transformations
-
--- | Shifts observations in a `TimeSeries` back by k.
--- Output length is @n-k@; @k < 0@ or @k >= n@ results in `InvalidLag`
-lag :: (U.Unbox t, U.Unbox y) => Int -> TimeSeries t y -> Either TimeSeriesError (TimeSeries t y)
-lag k ts
-  | U.null timeIndex          = Left EmptySeries
-  | k < 0                     = Left InvalidLag
-  | k >= n                    = Left InvalidLag
-  | otherwise                 = Right ts
-      { index = U.drop k timeIndex
-      , observations = U.take (n - k) obs
-      }
-  where
-    timeIndex = index ts
-    obs = observations ts
-    n = U.length timeIndex
-
--- | Shifts observations in a `TimeSeries` forward by k.
--- Output length is @n-k@; @k < 0@ or @k >= n@ results in `InvalidLead`
-lead :: (U.Unbox t, U.Unbox y) => Int -> TimeSeries t y -> Either TimeSeriesError (TimeSeries t y)
-lead k ts
-  | U.null timeIndex          = Left EmptySeries
-  | k < 0                     = Left InvalidLead
-  | k >= n                    = Left InvalidLead
-  | otherwise                 = Right ts
-      { index = U.take (n - k) timeIndex
-      , observations = U.drop k obs
-      }
-  where
-    timeIndex = index ts
-    obs = observations ts
-    n = U.length timeIndex
-
--- | Differences consecutive observations in a `TimeSeries`.
--- This function will drop the first value in the `TimeSeries` index.
-diff :: (Num y, U.Unbox t, U.Unbox y) => TimeSeries t y -> Either TimeSeriesError (TimeSeries t y)
-diff ts
-  | U.null timeIndex         = Left EmptySeries
-  | n == 1                   = Left InsufficientObservations
-  | otherwise                = Right ts
-      { index = U.drop 1 timeIndex
-      , observations = U.zipWith (-) (U.drop 1 (observations ts)) (observations ts) -- y' = y_t - y_(t-1)
-      }
-  where
-    timeIndex = index ts
-    n = U.length timeIndex
+-- * DataFrame Interop
 
 toFromDFExcept :: Either DataFrameException a -> Either ConversionError a
 toFromDFExcept = first DataFrameError
 
-fromDataFrame :: forall t. (Columnable t, U.Unbox t)
-              => T.Text -> T.Text -> DataFrame -> Either ConversionError (TimeSeries t Double)
-fromDataFrame colA colB df = do
-  indexV <- toFromDFExcept $ D.columnAsUnboxedVector (D.col @t colA) df
-  obsV   <- toFromDFExcept $ D.columnAsDoubleVector  (D.col @Double colB) df -- TODO: change to castWith when DataFrame compiles on my stack version (weird pragma B.S.)
-  first InvalidSeries $ mkTimeSeries indexV obsV
+-- | Converts two DataFrame columns to a 'TimeSeries', deriving the validity mask from
+-- NULL values: @(t, NULL)@ → @False@; @(t, y)@ → @True@ (even if @y@ is NaN).
+-- @(NULL, y)@ is rejected; @(NULL, NULL)@ rows are dropped before construction.
+fromDataFrame
+  :: forall t. (Columnable t, U.Unbox t)
+  => T.Text -> T.Text -> DataFrame -> Either ConversionError (TimeSeries t Double)
+fromDataFrame = undefined
 
-toDataFrame   :: (Columnable t, Columnable y, U.Unbox t, U.Unbox y)
-              => TimeSeries t y -> DataFrame
+toDataFrame
+  :: (Columnable t, Columnable y, U.Unbox t, U.Unbox y)
+  => TimeSeries t y -> DataFrame
 toDataFrame ts = D.fromNamedColumns
-  [ (T.pack $ "index",        D.fromUnboxedVector (index ts))
-  , (T.pack $ "observations", D.fromUnboxedVector (observations ts))
+  [ (T.pack "index",        D.fromUnboxedVector (index ts))
+  , (T.pack "observations", D.fromUnboxedVector (observations ts))
   ]


### PR DESCRIPTION
This commit has the strict test stuff in it; could be a really terrible implementation, could maybe not be? I'd appreciate a good review.

This arose after nullability became a concern in TimeSeries. I tried to do it the Apache Arrow way, with a bitmask for validity. 

(t, y) -> True, 
(NULL, y) -> rejected at construction, 
(NULL, NULL) -> meaningless, rejected at construction,
(t, Null) -> False

I didn't even test if this compiles. It's just a broad first draft with a lot of `undefined`s 
